### PR TITLE
feat: :sparkles: expose projection matrix, fov and modelViewProjectio…

### DIFF
--- a/src/geo/transform.ts
+++ b/src/geo/transform.ts
@@ -33,6 +33,7 @@ export class Transform {
     pixelsToGLUnits: [number, number];
     cameraToCenterDistance: number;
     mercatorMatrix: mat4;
+    projectionMatrix: mat4;
     modelViewProjectionMatrix: mat4;
     invModelViewProjectionMatrix: mat4;
     alignedModelViewProjectionMatrix: mat4;
@@ -890,6 +891,7 @@ export class Transform {
         // Apply center of perspective offset
         m[8] = -offset.x * 2 / this.width;
         m[9] = offset.y * 2 / this.height;
+        this.projectionMatrix = mat4.clone(m);
 
         mat4.scale(m, m, [1, -1, 1]);
         mat4.translate(m, m, [0, 0, -this.cameraToCenterDistance]);

--- a/src/render/draw_custom.ts
+++ b/src/render/draw_custom.ts
@@ -36,7 +36,7 @@ export function drawCustom(painter: Painter, sourceCache: SourceCache, layer: Cu
 
         context.setDepthMode(depthMode);
 
-        implementation.render(context.gl, painter.transform.customLayerMatrix(), {farZ: painter.transform._farZ, nearZ: painter.transform._nearZ, projMatrix: painter.transform.modelViewProjectionMatrix});
+        implementation.render(context.gl, painter.transform.customLayerMatrix(), {farZ: painter.transform._farZ, nearZ: painter.transform._nearZ, fov: painter.transform._fov, modelViewProjectionMatrix: painter.transform.modelViewProjectionMatrix, projectionMatrix: painter.transform.projectionMatrix});
 
         context.setDirty();
         painter.setBaseState();

--- a/src/style/style_layer/custom_style_layer.ts
+++ b/src/style/style_layer/custom_style_layer.ts
@@ -11,9 +11,9 @@ import {LayerSpecification} from '@maplibre/maplibre-gl-style-spec';
  * the `renderingMode` is `"3d"`, the z coordinate is conformal. A box with identical x, y, and z
  * lengths in mercator units would be rendered as a cube. {@link MercatorCoordinate.fromLngLat}
  * can be used to project a `LngLat` to a mercator coordinate.
- * @param args - Argument object. Properties are farZ, nearZ, projMatrix.
+ * @param args - Argument object. Properties are farZ, nearZ, fov modelViewProjectionMatrix, projectionMatrix.
  */
-type CustomRenderMethod = (gl: WebGLRenderingContext|WebGL2RenderingContext, matrix: mat4, args: { farZ: number; nearZ: number; projMatrix: mat4 }) => void;
+type CustomRenderMethod = (gl: WebGLRenderingContext|WebGL2RenderingContext, matrix: mat4, args: { farZ: number; nearZ: number; fov: number; modelViewProjectionMatrix: mat4; projectionMatrix: mat4 }) => void;
 
 /**
  * Interface for custom style layers. This is a specification for


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [] Add an entry to `CHANGELOG.md` under the `## main` section.

As discussed in https://github.com/maplibre/maplibre-gl-js/pull/3136
add  projectionMatrix, fov and modelViewProjectionMatrix parameters to custom render function. 
I have renamed projMatrix in the custom render function to match the one in transform.ts. Sicne transform.ts renaming is already a breaking change and fixes naming, we should do this in the custom render function, too.

I did not add the elevation though @Pessimistress asked for it.
